### PR TITLE
Add Wallet Step to landing page

### DIFF
--- a/src/components/Password/Password.tsx
+++ b/src/components/Password/Password.tsx
@@ -1,9 +1,7 @@
 import { useCallback, useState } from 'react';
-import { navigate } from '@reach/router';
 import PrimaryButton from 'components/core/Button/PrimaryButton';
 import colors from 'components/core/colors';
 import styled, { keyframes } from 'styled-components';
-import useAuthModal from 'hooks/useAuthModal';
 
 const HASH = -1695594350;
 
@@ -83,7 +81,7 @@ const StyledPasswordInput = styled.input`
   -webkit-text-security: disc;
 
   transition: outline 0.5s, background-color 0.5s;
-  z-index: 2;
+  z-index: 10;
 
   &active: {
     border-width: 2px;

--- a/src/components/Password/Password.tsx
+++ b/src/components/Password/Password.tsx
@@ -3,6 +3,7 @@ import { navigate } from '@reach/router';
 import PrimaryButton from 'components/core/Button/PrimaryButton';
 import colors from 'components/core/colors';
 import styled, { keyframes } from 'styled-components';
+import useAuthModal from 'hooks/useAuthModal';
 
 const HASH = -1695594350;
 
@@ -21,8 +22,11 @@ function generateHash(string: string) {
   }
   return hash;
 }
+type Props = {
+  handleNextClick: () => void;
+};
 
-function Password() {
+function Password({ handleNextClick }: Props) {
   const [isUnlocked, setIsUnlocked] = useState(false);
 
   const unlock = useCallback(() => {
@@ -42,8 +46,8 @@ function Password() {
   );
 
   const handleClick = useCallback(() => {
-    // show wallet connect selector
-  }, []);
+    handleNextClick();
+  }, [handleNextClick]);
 
   return (
     <StyledPasswordContainer>
@@ -79,7 +83,7 @@ const StyledPasswordInput = styled.input`
   -webkit-text-security: disc;
 
   transition: outline 0.5s, background-color 0.5s;
-  z-index: 10;
+  z-index: 2;
 
   &active: {
     border-width: 2px;

--- a/src/components/WalletSelector/WalletButton.tsx
+++ b/src/components/WalletSelector/WalletButton.tsx
@@ -53,7 +53,12 @@ function WalletButton({
   }
 
   return (
-    <StyledButton data-testid="wallet-button" onClick={handleClick} isConnecting disabled={isConnecting}>
+    <StyledButton
+      data-testid="wallet-button"
+      onClick={handleClick}
+      isConnecting
+      disabled={isConnecting}
+    >
       {isConnecting ? 'Connecting' : walletName}
       <Icon
         src={require(`assets/icons/${walletName.toLowerCase()}.svg`).default}
@@ -67,15 +72,15 @@ type StyledButtonProps = {
 };
 
 const Icon = styled.img`
-  width: 24px;
-  height: 24px;
+  width: 30px;
+  height: 30px;
   margin: 5px;
 `;
 
 const StyledButton = styled.button<StyledButtonProps>`
   background: white;
-  padding: 16px;
-  border: 1px solid ${colors.black};
+  padding: 12px 16px;
+  border: 2px solid ${colors.black};
   font-size: 16px;
   display: flex;
   align-items: center;

--- a/src/components/WalletSelector/WalletSelector.tsx
+++ b/src/components/WalletSelector/WalletSelector.tsx
@@ -9,6 +9,8 @@ import { useModal } from 'contexts/modal/ModalContext';
 import WalletButton from './WalletButton';
 import { isLoggedInState } from 'contexts/auth/types';
 import colors from 'components/core/colors';
+import { Text } from 'components/core/Text/Text';
+import { navigate } from '@reach/router';
 
 const walletConnectorMap: Record<string, AbstractConnector> = {
   Metamask: injected,
@@ -59,14 +61,13 @@ function WalletSelector() {
   }, [library, account]);
 
   const { logIn } = useAuthActions();
-  const { hideModal } = useModal();
 
   useEffect(() => {
-    if (account && isConnecting && !isLoggedIn && signer) {
+    if (account && isConnecting && signer) {
       signMessageAndAuthenticate(account, signer)
         .then((jwt) => {
           logIn(jwt);
-          hideModal();
+          navigate('/welcome');
         })
         .catch((err) => {
           setErrorCode(err.code);
@@ -74,7 +75,7 @@ function WalletSelector() {
           return;
         });
     }
-  }, [account, hideModal, isConnecting, isLoggedIn, logIn, signer]);
+  }, [account, isConnecting, isLoggedIn, logIn, signer]);
 
   if (errorCode) {
     const errorMessage = getErrorMessage(errorCode);
@@ -153,20 +154,25 @@ const StyledWalletSelector = styled.div`
   flex-direction: column;
 `;
 
-const StyledHeader = styled.p`
-  color: black;
-  font-size: 24px;
+const StyledHeader = styled(Text)`
+  color: ${colors.black};
+  line-height: initial;
+  font-size: 18px;
+
+  margin-bottom: 16px;
 `;
 
 const StyledRetryButton = styled.button`
+  align-self: center;
   text-align: center;
-  border: 1px solid ${colors.black};
+
   padding: 10px;
-  background: none;
-  font-family: inherit;
   margin-top: 20px;
   width: 50%;
-  align-self: center;
+
+  border: 1px solid ${colors.black};
+  background: none;
+  font-family: inherit;
 `;
 
 export default WalletSelector;

--- a/src/components/WalletSelector/WalletSelector.tsx
+++ b/src/components/WalletSelector/WalletSelector.tsx
@@ -5,7 +5,6 @@ import { injected, walletconnect } from 'connectors/index';
 import { AbstractConnector } from '@web3-react/abstract-connector';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAuthActions, useAuthState } from 'contexts/auth/AuthContext';
-import { useModal } from 'contexts/modal/ModalContext';
 import WalletButton from './WalletButton';
 import { isLoggedInState } from 'contexts/auth/types';
 import colors from 'components/core/colors';

--- a/src/scenes/CollectionCreationFlow/CollectionCreationFlow.tsx
+++ b/src/scenes/CollectionCreationFlow/CollectionCreationFlow.tsx
@@ -1,12 +1,21 @@
 import { memo } from 'react';
-import { RouteComponentProps } from '@reach/router';
+import { Redirect, RouteComponentProps } from '@reach/router';
 import { Wizard, Steps, Step } from 'react-albus';
 import WizardFooter from './WizardFooter';
 import CreateFirstCollection from './steps/CreateFirstCollection';
 import AddNfts from './steps/AddNfts/AddNfts';
 import OrganizeCollections from './steps/OrganizeCollections';
+import { useAuthState } from 'contexts/auth/AuthContext';
+import { isLoggedInState } from 'contexts/auth/types';
 
 function CollectionCreationFlow(_: RouteComponentProps) {
+  const authState = useAuthState();
+  const isLoggedIn = isLoggedInState(authState);
+
+  if (!isLoggedIn) {
+    return <Redirect to="/" />;
+  }
+
   return (
     <Wizard
       render={({ step, next, previous }) => {

--- a/src/scenes/Home/Home.tsx
+++ b/src/scenes/Home/Home.tsx
@@ -1,9 +1,10 @@
 import { RouteComponentProps } from '@reach/router';
-import { memo } from 'react';
+import { memo, useCallback, useState } from 'react';
 import styled from 'styled-components';
 import Password from 'components/Password/Password';
 import { Text } from 'components/core/Text/Text';
 import colors from 'components/core/colors';
+import WalletSelector from 'components/WalletSelector/WalletSelector';
 
 function Home(_: RouteComponentProps) {
   // on dev, this will route to localhost:4000/api/test
@@ -11,11 +12,24 @@ function Home(_: RouteComponentProps) {
   // const { data, error } = useSwr('/test');
   // console.log('the result', data, error);
 
+  const [showWalletSelector, setShowWalletSelector] = useState(false);
+  const handleNextClick = useCallback(() => {
+    setShowWalletSelector(true);
+  }, []);
+
+  if (showWalletSelector) {
+    return (
+      <StyledHome>
+        <WalletSelector />
+      </StyledHome>
+    );
+  }
+
   return (
     <StyledHome>
       <StyledHeader>GALLERY</StyledHeader>
       <Text>Show your collection to the world</Text>
-      <Password />
+      <Password handleNextClick={handleNextClick} />
     </StyledHome>
   );
 }
@@ -25,7 +39,7 @@ const StyledHome = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 15vh;
+  margin-top: 20vh;
 `;
 
 const StyledHeader = styled.p`

--- a/src/scenes/Routes.tsx
+++ b/src/scenes/Routes.tsx
@@ -5,6 +5,7 @@ import Auth from 'scenes/Auth/Auth';
 import NotFound from 'scenes/NotFound/NotFound';
 import Gallery from 'scenes/Gallery/Gallery';
 import CollectionCreationFlow from 'scenes/CollectionCreationFlow/CollectionCreationFlow';
+import Welcome from 'scenes/Welcome/Welcome';
 
 export default function Routes() {
   return (
@@ -13,6 +14,7 @@ export default function Routes() {
       <AppContainer path="/">
         <Home path="/" />
         <Auth path="/auth" />
+        <Welcome path="/welcome"></Welcome>
         <CollectionCreationFlow path="/create" />
         <Gallery path="/:usernameOrWalletAddress" />
         <NotFound default path="404" />

--- a/src/scenes/Welcome/Welcome.tsx
+++ b/src/scenes/Welcome/Welcome.tsx
@@ -1,0 +1,37 @@
+import { navigate, Redirect, RouteComponentProps } from '@reach/router';
+import styled from 'styled-components';
+import ActionText from 'components/core/ActionText/ActionText';
+import { useCallback } from 'react';
+import { useAuthState } from 'contexts/auth/AuthContext';
+import { isLoggedInState } from 'contexts/auth/types';
+
+function Welcome(_: RouteComponentProps) {
+  const authState = useAuthState();
+  const isLoggedIn = isLoggedInState(authState);
+
+  const handleClick = useCallback(() => {
+    navigate('/create');
+  }, []);
+
+  if (!isLoggedIn) {
+    return <Redirect to="/" />;
+  }
+
+  return (
+    <StyledWelcome>
+      <StyledActionText>YOU ARE PICASSO</StyledActionText>
+      <button onClick={handleClick}></button>
+    </StyledWelcome>
+  );
+}
+const StyledActionText = styled(ActionText)`
+  font-size: 100px;
+`;
+const StyledWelcome = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 140px;
+`;
+
+export default Welcome;


### PR DESCRIPTION
The wallet step appears after the user enters the password. After they connect their wallet, they are authenticated and are redirected to the Welcome screen.

additional changes:
  - add placeholder welcome page shown before /create
  - redirect non logged in users from /create to /